### PR TITLE
Reseller API account list pagination [#109162454]

### DIFF
--- a/index.php
+++ b/index.php
@@ -229,11 +229,9 @@
 					sleep(2);
 					$account_list_page++;
 					$account_list_nextpage = $ac->api("account/list?search={$search}&page={$account_list_page}");
-					if ($account_list_nextpage->count) {
+					$account_list->count = $account_list_nextpage->count;
+					if ($account_list->count) {
 						$account_list->accounts = array_merge($account_list->accounts, $account_list_nextpage->accounts);
-					} else {
-						// No results on this page.
-						break;
 					}
 				}
 

--- a/index.php
+++ b/index.php
@@ -220,8 +220,24 @@
 
 				$_SESSION["account_list_search"] = $search = $_POST["account_filter"];
 //$ac->debug = true;
-				$_SESSION["account_list"] = $account_list = $ac->api("account/list?search={$search}");
-//dbg($account_list);
+				$account_list_page = 1;
+				$account_list = $ac->api("account/list?search={$search}&page={$account_list_page}");
+
+				// Fetch additional pages.
+				while ($account_list->count == 20) {
+					// Since we only fetch 20 per page, if 20 are returned, there could be another page.
+					sleep(2);
+					$account_list_page++;
+					$account_list_nextpage = $ac->api("account/list?search={$search}&page={$account_list_page}");
+					if ($account_list_nextpage->count) {
+						$account_list->accounts = array_merge($account_list->accounts, $account_list_nextpage->accounts);
+					} else {
+						// No results on this page.
+						break;
+					}
+				}
+
+				$_SESSION["account_list"] = $account_list;
 
 			}
 			elseif ($step == 102) {
@@ -463,7 +479,7 @@
 
 			?>
 
-			<h2>Accounts</h2>
+			<h2>Accounts (<?php echo count($_SESSION["account_list"]->accounts); ?>)</h2>
 
 			<table border="1" cellspacing="0" cellpadding="3">
 


### PR DESCRIPTION
The example script should fetch and display **all** accounts, not just the first 20. Also showing the total number of accounts in parenthesis.
